### PR TITLE
fix: main.iml 못찾는 버그 픽스

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -8,7 +8,7 @@
         <processorPath useClasspath="false">
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.30/f195ee86e6c896ea47a1d39defbe20eb59cd149d/lombok-1.18.30.jar" />
         </processorPath>
-        <module name="Perfume-Pedia.main" />
+        <module name="com.perfume-pedia.Perfume-Pedia.main" />
       </profile>
     </annotationProcessing>
     <bytecodeTargetLevel target="17" />

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+    <component name="ProjectModuleManager">
+        <modules>
+            <module fileurl="file://$PROJECT_DIR$/.idea/modules/Perfume-Pedia.main.iml" filepath="$PROJECT_DIR$/.idea/modules/Perfume-Pedia.main.iml" />
+        </modules>
+    </component>
+</project>

--- a/.idea/modules/Perfume-Pedia.main.iml
+++ b/.idea/modules/Perfume-Pedia.main.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$/../../build/generated/sources/annotationProcessor/java/main">
+      <sourceFolder url="file://$MODULE_DIR$/../../build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
+    </content>
+  </component>
+</module>


### PR DESCRIPTION
Cannot load settings from file '/Users/argo/workspace/PERFUEM_PROJECT/perfumepedia-backend/.idea/modules/Perfume-Pedia.main.iml': content truncated File content will be recreated 버그 픽스