### PR TITLE
feat > WordSplit test

### DIFF
--- a/src/main/java/com/perfumepedia/PerfumePedia/insertService/WordSplit.java
+++ b/src/main/java/com/perfumepedia/PerfumePedia/insertService/WordSplit.java
@@ -2,6 +2,7 @@ package com.perfumepedia.PerfumePedia.insertService;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class WordSplit {
 
@@ -10,16 +11,26 @@ public class WordSplit {
         List<String> result = new ArrayList<>();
 
         for (int i = 0; i < word.length(); i++) {
-            for (int j = i + 1; j <= word.length(); j++) {
-                String subString = word.substring(i, j).trim();
+            // 공백으로 시작하는 경우 제외
+            if(word.substring(i, i+1).isBlank())
+                continue;
 
-                if(!subString.isEmpty()) {
-                    result.add(subString);
+            for (int j = i + 1; j <= word.length(); j++) {
+                // 앞 뒤 공백 제거
+                String subString = word.substring(i, j).trim();
+                result.add(subString);
+
+                // 중간 공백 여부 확인 -> 정규식 활용
+                if(subString.matches(".*\\p{Z}+.*")){
+                    // 모든 공백 제거
+                    String subBlankedString = subString.replaceAll("\\p{Z}", "");
+                    result.add(subBlankedString);
                 }
             }
         }
 
-        return result;
+        // 중복제거 리스트 반환
+        return result.stream().distinct().collect(Collectors.toList());
     }
 
 

--- a/src/test/java/com/perfumepedia/PerfumePedia/insertService/WordSplitTest.java
+++ b/src/test/java/com/perfumepedia/PerfumePedia/insertService/WordSplitTest.java
@@ -1,0 +1,71 @@
+package com.perfumepedia.PerfumePedia.insertService;
+
+
+import lombok.RequiredArgsConstructor;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import static org.junit.Assert.*;
+
+@SpringBootTest
+@Transactional
+@RequiredArgsConstructor
+public class WordSplitTest {
+
+    WordSplit wordSplit = new WordSplit();
+
+    @Test
+    public void 앞뒤_공백_제거_확인() throws Exception{
+        //given
+        String keyword = " 앞뒤공백별칭테스트 ";
+
+        //when
+        List<String> words = wordSplit.splitName(keyword);
+
+        //then
+        boolean hasGapFront = words.stream().anyMatch(word -> word.matches("\\p{Z}"));
+        assertTrue(!hasGapFront);
+    }
+
+    @Test
+    public void 공백만_있는_별칭_여부_확인() throws Exception{
+        //given
+        String keyword = " 중간 공백 별칭 테스트 ";
+
+        //when
+        List<String> words = wordSplit.splitName(keyword);
+
+        //then
+        boolean hasGapFront = words.stream().anyMatch(word -> word.matches("\\p{Z}"));
+        assertTrue(!hasGapFront);
+    }
+
+    @Test
+    public void 중복_별칭_여부_확인() throws Exception{
+        //given
+        String keyword = " 같은 별칭 같은 별칭 ";
+        String duplicateWord1 = "같은";
+        String duplicateWord2 = "별칭";
+        String duplicateWord3 = "은별";
+        String duplicateWord4 = "같은별칭";
+
+
+        //when
+        List<String> words = wordSplit.splitName(keyword);
+
+        //then
+        long countByDuplicateWord1 = words.stream().filter(word -> duplicateWord1.equals(word)).count();
+        long countByDuplicateWord2 = words.stream().filter(word -> duplicateWord2.equals(word)).count();
+        long countByDuplicateWord3 = words.stream().filter(word -> duplicateWord3.equals(word)).count();
+        long countByDuplicateWord4 = words.stream().filter(word -> duplicateWord4.equals(word)).count();
+
+        assertEquals(1L, countByDuplicateWord1);
+        assertEquals(1L, countByDuplicateWord2);
+        assertEquals(1L, countByDuplicateWord3);
+        assertEquals(1L, countByDuplicateWord4);
+    }
+
+}


### PR DESCRIPTION
1. 불필요한 반복문 제거
- 키워드가 공백으로 시작하는 경우 제외 시킴
2. 중간 공백이 있는 경우 별칭 전환
- ex. 당근 인턴: 당근 인턴, 당근인턴 포함되도록 함